### PR TITLE
`jumpTo` doesn't exit from the current step chain.

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ function errInfo(stepName, paramIdx, paramName) {
 }
 function StepObj(params, jumpTo, data) {
 	this._params = params;
-	this._jumpTo = jumpTo;
+	this.jumpTo = jumpTo;
 	this.data = data;
 }
 StepObj.prototype = {
@@ -95,13 +95,6 @@ StepObj.prototype = {
 		emitter.on('data', function (chunk) { chunks.push(chunk); });
 		emitter.on('error', function(err) { params.error(err, errInfo(params.name, paramIdx, name)); });
 		emitter.on('end', function() { params.done(paramIdx, chunks); });
-	},
-	jumpTo: function(func, args) {
-		if(Object.prototype.toString.call(func) === "[object Function]") {
-			return func.apply(this, args);
-		}
-
-		this._jumpTo(func, args);
 	}
 };
 
@@ -110,14 +103,19 @@ function TwoStep() {
 	var curIdx = 0;
 	var data = {};
 
-	function jumpTo(name, args) {
-		for(var i = 0; i < steps.length; i++) {
-			if(steps[i].name !== name) { continue; }
+	function jumpTo(func, args) {
+    if (typeof func === 'function') {
+      curIdx = Number.MAX_VALUE;
+      func.apply(null, args);
+    } else {
+      for(var i = 0; i < steps.length; i++) {
+        if(steps[i].name !== func) { continue; }
 
-			curIdx = i;
+        curIdx = i;
 
-			break;
-		}
+        break;
+      }
+    }
 		nextStep.apply(null, args);
 	}
 

--- a/test/jumpTo.js
+++ b/test/jumpTo.js
@@ -33,5 +33,34 @@ vows.describe("Test `this.val`").addBatch({
 			assert.ok(!data["last"].args[0], "The error argument was incorrectly set");
 			assert.equal(data["last"].args[1], "hello", "The incorrect arguments were sent");
 		}
-	}
+	},
+  "bail out if a function was specified": {
+    topic: function() {
+      var callback = this.callback;
+      var visited = [];
+      function externalFunc() {
+        visited.push('externalFunc');
+        callback(visited, Array.prototype.slice.call(arguments));
+      }
+      TwoStep(
+        function s1() {
+          visited.push('s1');
+          this.jumpTo(externalFunc, ['foo', 'bar', 'baz']);
+        },
+        function s2() {
+          visited.push('s2');
+        },
+        function s3() {
+          visited.push('s3');
+        },
+        callback
+      );
+    },
+    "correct callbacks were called": function(visited, _) {
+      assert.deepEqual(visited, ['s1', 'externalFunc']);
+    },
+    "correct arguments were passed to external function": function(_, externalFuncArgs) {
+      assert.deepEqual(externalFuncArgs, ['foo', 'bar', 'baz']);
+    }
+  }
 }).export(module);


### PR DESCRIPTION
Calling `jumpTo()` with an outside function calls that function and then proceeds to execute the remaining steps. This commit fixes that: no steps will be executed after a jump to an outside function.
